### PR TITLE
Update GridContext.tsx to add children property

### DIFF
--- a/src/GridContext.tsx
+++ b/src/GridContext.tsx
@@ -38,7 +38,7 @@ interface GridProviderProps<T> {
   uiActionRendererList?: UIActionRenderer[]
 }
 
-export const GridProvider: React.FC<GridProviderProps<any>> = (
+export const GridProvider: React.FC<React.PropsWithChildren<GridProviderProps<any>>> = (
   {
     identifierProperty = "id",
     columns: dataProperties,


### PR DESCRIPTION
Since React 18, it is necessary to add children explicitly as a prop to a component that takes children.